### PR TITLE
Fix typo at detectingaslownode.rst

### DIFF
--- a/galeracluster/source/detectingaslownode.rst
+++ b/galeracluster/source/detectingaslownode.rst
@@ -31,7 +31,7 @@ There are two status variables used in finding slow nodes:
 
   .. code-block:: mysql
 
-     SHOW STATUS LIKE 'wresp_local_recv_queue_avg';
+     SHOW STATUS LIKE 'wsrep_local_recv_queue_avg';
 
      +----------------------------+---------+
      | Variable_name              | Value   |


### PR DESCRIPTION
"wresp_local_recv_queue_avg" is typo.
"wsrep_local_recv_queue_avg" is correct parameter name.
